### PR TITLE
JCLOUDS-79: Fix cli start scripts for Windows

### DIFF
--- a/assembly/src/main/filtered-resources/win/bin/jclouds.bat
+++ b/assembly/src/main/filtered-resources/win/bin/jclouds.bat
@@ -88,7 +88,7 @@ set CATEGORY=%1
 set ACTION=%2
 
 :EXECUTE
-﻿SHIFT
+SHIFT
 SHIFT
     if "%SHIFT%" == "true" SET ARGS=%2 %3 %4 %5 %6 %7 %8
     if not "%SHIFT%" == "true" SET ARGS=%1 %2 %3 %4 %5 %6 %7 %8

--- a/assembly/src/main/filtered-resources/win/bin/shell.bat
+++ b/assembly/src/main/filtered-resources/win/bin/shell.bat
@@ -112,8 +112,10 @@ if "%KARAF_DEBUG%" == "" goto :KARAF_DEBUG_END
 :KARAF_DEBUG_END
 
 set CLASSPATH=%KARAF_HOME%\system\org\apache\jclouds\cli\runner\${project.version}\runner-${project.version}.jar
+set CLASSPATH=%CLASSPATH%;%KARAF_HOME%\system\org\apache\jclouds\jclouds-core\${jclouds.version}\jclouds-core-${jclouds.version}.jar
+set CLASSPATH=%CLASSPATH%;%KARAF_HOME%\system\org\apache\jclouds\jclouds-blobstore\${jclouds.version}\jclouds-blobstore-${jclouds.version}.jar
 set CLASSPATH=%CLASSPATH%;%KARAF_HOME%\system\org\apache\karaf\shell\org.apache.karaf.shell.console\${karaf.version}\org.apache.karaf.shell.console-${karaf.version}.jar
-set CLASSPATH="%CLASSPATH%;%KARAF_HOME%/lib/other/slf4j-api-${slf4j.version}.jar;%KARAF_HOME%/lib/other/slf4j-log4j12-${slf4j.version}.jar;%KARAF_HOME%/lib/other/log4j-${log4j.version}.jar"
+set CLASSPATH=%CLASSPATH%;%KARAF_HOME%\lib\other\slf4j-api-${slf4j.version}.jar;%KARAF_HOME%\lib\other\slf4j-log4j12-${slf4j.version}.jar;%KARAF_HOME%\lib\other\log4j-${log4j.version}.jar
 set CLASSPATH=%CLASSPATH%;%KARAF_HOME%\etc\log4j.properties
 
 :EXECUTE


### PR DESCRIPTION
Works for me:

```
C:\...\jclouds-cli-1.6.1-SNAPSHOT\bin>set OPTS=-Djclouds.provider=aws-s3 -Djclouds.identity=$IDENTITY -Djclouds.credential=$CREDENTIAL

C:\...\jclouds-cli-1.6.1-SNAPSHOT\bin>jclouds.bat blobstore container-list
shell.bat: Ignoring predefined value for KARAF_HOME
log4j:WARN No appenders could be found for logger (org.jclouds.rest.internal.InvokeSyncToAsyncHttpMethod).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
Authorization error: The AWS Access Key Id you provided does not exist in our records.
```
