### PR TITLE
Warnings should be printed on STDERR.

### DIFF
--- a/assembly/src/main/filtered-resources/unix/bin/shell
+++ b/assembly/src/main/filtered-resources/unix/bin/shell
@@ -48,7 +48,7 @@ if [ "x$JAVA_MAX_PERM_MEM" = "x" ]; then
 fi
 
 warn() {
-    echo "${PROGNAME}: $*"
+    echo "${PROGNAME}: $*" >&2
 }
 
 die() {

--- a/assembly/src/main/filtered-resources/win/bin/shell.bat
+++ b/assembly/src/main/filtered-resources/win/bin/shell.bat
@@ -48,7 +48,7 @@ if "%JAVA_MAX_MEM%" == "" (
 goto BEGIN
 
 :warn
-    echo %PROGNAME%: %*
+    echo %PROGNAME%: %* >&2
 goto :EOF
 
 :BEGIN


### PR DESCRIPTION
Change the jclouds-cli shell scripts to print warnings to STDERR, as
opposed to STDOUT like they do right now.
