### PR TITLE
JCLOUDS-104: Cleaning up CLI POMs

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -20,17 +20,15 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.jclouds.cli</groupId>
     <artifactId>jclouds-cli-project</artifactId>
-    <relativePath>../jclouds-cli-project</relativePath>
+    <relativePath>../project</relativePath>
     <version>1.7.0-SNAPSHOT</version>
   </parent>
-  <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.apache.jclouds.cli</groupId>
   <artifactId>jclouds-cli-assembly</artifactId>
-  <version>1.7.0-SNAPSHOT</version>
   <name>jclouds :: cli :: assembly</name>
 
   <dependencies>

--- a/branding/pom.xml
+++ b/branding/pom.xml
@@ -19,17 +19,15 @@
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.jclouds.cli</groupId>
     <artifactId>jclouds-cli-project</artifactId>
-    <relativePath>../jclouds-cli-project</relativePath>
+    <relativePath>../project</relativePath>
     <version>1.7.0-SNAPSHOT</version>
   </parent>
-  <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.apache.jclouds.cli</groupId>
   <artifactId>branding</artifactId>
-  <version>1.7.0-SNAPSHOT</version>
   <packaging>bundle</packaging>
   <name>jclouds :: cli :: branding</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,15 +22,13 @@
   <parent>
     <groupId>org.apache.jclouds.cli</groupId>
     <artifactId>jclouds-cli-project</artifactId>
-    <relativePath>jclouds-cli-project</relativePath>
+    <relativePath>project</relativePath>
     <version>1.7.0-SNAPSHOT</version>
   </parent>
 
-  <groupId>org.apache.jclouds.cli</groupId>
   <artifactId>jclouds-cli</artifactId>
   <packaging>pom</packaging>
   <name>Apache jclouds :: cli</name>
-  <version>1.7.0-SNAPSHOT</version>
 
   <url>http://jclouds.apache.org</url>
   <licenses>
@@ -57,17 +55,17 @@
     </developer>
     <developer>
       <id>abayer</id>
-      <name>Andew Bayer</name>
+      <name>Andrew Bayer</name>
       <email>abayer@apache.org</email>
       <url>http://andrewbayer.com</url>
     </developer>
   </developers>
 
   <modules>
+    <module>project</module>
     <module>branding</module>
     <module>assembly</module>
     <module>runner</module>
-    <module>jclouds-cli-project</module>
   </modules>
   
   <repositories>

--- a/project/pom.xml
+++ b/project/pom.xml
@@ -19,7 +19,7 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  
+
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
@@ -28,8 +28,8 @@
 
   <groupId>org.apache.jclouds.cli</groupId>
   <artifactId>jclouds-cli-project</artifactId>
+  <version>1.7.0-SNAPSHOT</version>
   <packaging>pom</packaging>
-  <!-- VERSION same as parent -->
   <name>Apache jclouds :: cli</name>
 
   <url>http://jclouds.apache.org</url>
@@ -61,7 +61,7 @@
       <email>abayer@apache.org</email>
       <url>http://andrewbayer.com</url>
     </developer>
-  </developers>  
+  </developers>
 
   <properties>
     <!-- Karaf Version Dependencies -->
@@ -89,11 +89,11 @@
     <build-helper-maven-plugin.version>1.5</build-helper-maven-plugin.version>
 
     <sourceReleaseAssemblyDescriptor>source-release-zip-tar</sourceReleaseAssemblyDescriptor>
-    
+
     <!-- Skip the duplicate finder. Note that otherwise maven will fail building -->
     <skipDuplicateFinder>true</skipDuplicateFinder>
   </properties>
-  
+
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -131,8 +131,8 @@
         <version>${log4j.version}</version>
       </dependency>
     </dependencies>
-  </dependencyManagement>  
-  
+  </dependencyManagement>
+
   <build>
     <plugins>
       <plugin>

--- a/runner/pom.xml
+++ b/runner/pom.xml
@@ -19,17 +19,15 @@
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.jclouds.cli</groupId>
     <artifactId>jclouds-cli-project</artifactId>
-    <relativePath>../jclouds-cli-project</relativePath>
+    <relativePath>../project</relativePath>
     <version>1.7.0-SNAPSHOT</version>
   </parent>
-  <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.apache.jclouds.cli</groupId>
   <artifactId>runner</artifactId>
-  <version>1.7.0-SNAPSHOT</version>
   <name>jclouds :: cli :: runner</name>
 
   <dependencies>


### PR DESCRIPTION
- module jclouds-cli-project -> project
- removing unnecessary duplicate versions and group IDs

Follow-on from bb56570

Tested as follows:
- `mvn clean package` succeeds
- `mvn release:prepare` seems to ["do the right thing"](http://pastie.org/private/uu7wabhqfpdzzplzibgsza)

**Please verify by running `mvn release:prepare` locally**
