### PR TITLE
JCLOUDS-720: Renames jclouds-cli artifact IDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 .settings
 target
 eclipse-classes
+*.DS_STORE

--- a/branding/pom.xml
+++ b/branding/pom.xml
@@ -27,7 +27,7 @@
     <version>2.0.0-SNAPSHOT</version>
   </parent>
 
-  <artifactId>branding</artifactId>
+  <artifactId>jclouds-cli-branding</artifactId>
   <packaging>bundle</packaging>
   <name>jclouds :: cli :: branding</name>
 

--- a/runner/pom.xml
+++ b/runner/pom.xml
@@ -27,7 +27,7 @@
     <version>2.0.0-SNAPSHOT</version>
   </parent>
 
-  <artifactId>runner</artifactId>
+  <artifactId>jclouds-cli-runner</artifactId>
   <name>jclouds :: cli :: runner</name>
 
   <dependencies>


### PR DESCRIPTION
This PR fixes renames the `branding` artifact to `jclouds-cli-branding`, and the `runner` artifact to `jclouds-cli-runner`. It also updates the `.gitignore` file to ignore Mac OS specific `.DS_Store` files.

JIRA: https://issues.apache.org/jira/browse/JCLOUDS-720

This is dependent on PR #19 being merged first. This should _not_ be backported to the 1.8.x branch due to the renaming of the artifact IDs.
