### PR TITLE
JCLOUDS-780: Remove vcloud feature

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -190,7 +190,6 @@
                 <feature>jclouds-api-rackspace-cloudidentity</feature>
                 <feature>jclouds-api-s3</feature>
                 <feature>jclouds-api-swift</feature>
-                <feature>jclouds-api-vcloud</feature>
                 <feature>jclouds-aws-cloudwatch</feature>
                 <feature>jclouds-aws-ec2</feature>
                 <feature>jclouds-aws-s3</feature>


### PR DESCRIPTION
The feature was removed from jclouds-karaf but was still present in the CLI, making the build fail.
