### PR TITLE
Fixing reference to branding bundle in the CLI assembly

### DIFF
--- a/assembly/src/main/assembly/unix.xml
+++ b/assembly/src/main/assembly/unix.xml
@@ -133,7 +133,7 @@
             <outputFileNameMapping>jclouds-version.jar</outputFileNameMapping>
             <fileMode>0644</fileMode>
             <includes>
-                <include>org.apache.jclouds.cli:branding</include>
+                <include>org.apache.jclouds.cli:jclouds-cli-branding</include>
             </includes>
             <useTransitiveDependencies>false</useTransitiveDependencies>
         </dependencySet>

--- a/assembly/src/main/assembly/win.xml
+++ b/assembly/src/main/assembly/win.xml
@@ -131,7 +131,7 @@
             <outputFileNameMapping>jclouds-version.jar</outputFileNameMapping>
             <fileMode>0644</fileMode>
             <includes>
-                <include>org.apache.jclouds.cli:branding</include>
+                <include>org.apache.jclouds.cli:jclouds-cli-branding</include>
             </includes>
             <useTransitiveDependencies>false</useTransitiveDependencies>
         </dependencySet>


### PR DESCRIPTION
Follow-up to 01dcca14

Before change:

![image](https://cloud.githubusercontent.com/assets/223702/7056677/db562f1e-de1b-11e4-9773-a82d9981588f.png)

After change:

![image](https://cloud.githubusercontent.com/assets/223702/7056678/df2462d2-de1b-11e4-94b5-40d768108e7f.png)

Also needs to be backported to 1.9.x