### PR TITLE
Allow to configure the boot features. All enabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,15 +116,13 @@ To start the interactive shell:
 ./bin/jclouds-cli
 
 The interactive shell is a lightweight container powered by [Apache Karaf](http://karaf.apache.org) which is modular and extensible.
-Out of the box it has installed support of Amazon EC2, Amazon S3 and Chef. But you can easily add or remove providers, apis, drivers etc using the features commands:
+Out of the box it has installed support of all compute, blobstore providers and Chef. You can easily add or remove providers, apis, drivers etc using the features commands:
 
-    features:list
+    feature:list
 
-Will list all the available features, that you can install. Some examples of adding additional features:
+Will list all the available features, that you can install. Some examples of adding additional feature:
 
-    features:install jclouds-api-cloudstack
-    features:install jclouds-api-openstack-nova
-
+    feature:install jclouds-cloudsigma2-mia
 
 All commands that are available from the script are also available in the interactive mode. The only difference is that in the interactive mode the **category** and **action** are encoded in the command name.
 So all jclouds and chef commands follow the following format:
@@ -378,15 +376,7 @@ By default the delimiter is the semicolon symbol, but for each command category 
     hardware.headers=[id],[ram],[cpu],[cores]
 
 
-
 See also
 --------
 * https://github.com/jclouds/jclouds/
 * https://github.com/jclouds/jclouds-karaf/
-* https://github.com/jclouds/jclouds-chef/
-
-
-
-
-
-

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -29,7 +29,7 @@
   </parent>
 
   <artifactId>jclouds-cli-assembly</artifactId>
-  <name>jclouds :: cli :: assembly</name>
+  <name>Apache jclouds :: cli :: assembly</name>
 
   <dependencies>
     <dependency>
@@ -182,60 +182,11 @@
                 <feature>log</feature>
                 <feature>shell-compat</feature>
                 <feature>wrap</feature>
-                <feature>jclouds</feature>
-                <feature>jclouds-commands</feature>
-                <feature>jclouds-compute</feature>
-                <feature>jclouds-guice</feature>
-                <feature>jclouds-services</feature>
-                <feature>jclouds-url-handler</feature>
-                <feature>jclouds-api-atmos</feature>
-                <feature>jclouds-api-byon</feature>
-                <feature>jclouds-api-chef</feature>
-                <feature>jclouds-api-cloudsigma2</feature>
-                <feature>jclouds-api-cloudstack</feature>
-                <feature>jclouds-api-elasticstack</feature>
-                <feature>jclouds-api-ec2</feature>
-                <feature>jclouds-api-filesystem</feature>
-                <feature>jclouds-api-openstack-nova</feature>
-                <feature>jclouds-api-openstack-cinder</feature>
-                <feature>jclouds-api-openstack-swift</feature>
-                <feature>jclouds-api-rackspace-cloudidentity</feature>
-                <feature>jclouds-api-s3</feature>
-                <feature>jclouds-aws-cloudwatch</feature>
-                <feature>jclouds-aws-ec2</feature>
-                <feature>jclouds-aws-s3</feature>
-                <feature>jclouds-azureblob</feature>
-                <feature>jclouds-azurecompute-arm</feature>
-                <feature>jclouds-b2</feature>
+                <feature>jclouds-all-compute</feature>
+                <feature>jclouds-all-blobstore</feature>
                 <feature>jclouds-chef</feature>
-                <feature>jclouds-cloudsigma2-hnl</feature>
-                <feature>jclouds-cloudsigma2-lvs</feature>
-                <feature>jclouds-cloudsigma2-sjc</feature>
-                <feature>jclouds-cloudsigma2-wdc</feature>
-                <feature>jclouds-cloudsigma2-zrh</feature>
-                <feature>jclouds-digitalocean2</feature>
-                <feature>jclouds-elastichosts-lon-b</feature>
-                <feature>jclouds-elastichosts-lon-p</feature>
-                <feature>jclouds-elastichosts-sat-p</feature>
-                <feature>jclouds-elastichosts-lax-p</feature>
-                <feature>jclouds-elastichosts-tor-p</feature>
-                <feature>jclouds-gogrid</feature>
-                <feature>jclouds-go2cloud-jhb1</feature>
-                <feature>jclouds-google-compute-engine</feature>
-                <feature>jclouds-google-cloud-storage</feature>
-                <feature>jclouds-openhosting-east1</feature>
-                <feature>jclouds-packet</feature>
-                <feature>jclouds-profitbricks</feature>
-                <feature>jclouds-rackspace-cloudloadbalancers-uk</feature>
-                <feature>jclouds-rackspace-cloudloadbalancers-us</feature>
-                <feature>jclouds-rackspace-cloudservers-uk</feature>
-                <feature>jclouds-rackspace-cloudservers-us</feature>
-                <feature>jclouds-rackspace-cloudfiles-uk</feature>
-                <feature>jclouds-rackspace-cloudfiles-us</feature>
-                <feature>jclouds-serverlove-z1-man</feature>
-                <feature>jclouds-skalicloud-sdg-my</feature>
-                <feature>jclouds-softlayer</feature>
-                <feature>jclouds-vagrant</feature>
+                <feature>jclouds-labs-all-compute</feature>
+                <feature>jclouds-labs-all-blobstore</feature>
               </features>
               <includeMvnBasedDescriptors>true</includeMvnBasedDescriptors>
               <repository>target/features-repo</repository>

--- a/assembly/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
+++ b/assembly/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
@@ -15,10 +15,8 @@
 # limitations under the License.
 #
 featuresRepositories=\
-  mvn:org.apache.karaf.features/standard/${karaf.version}/xml/features, \
-  mvn:org.apache.jclouds.karaf/jclouds-karaf/${jclouds.karaf.version}/xml/features, \
+  mvn:org.apache.karaf.features/standard/${karaf.version}/xml/features,\
+  mvn:org.apache.jclouds.karaf/jclouds-karaf/${jclouds.karaf.version}/xml/features,\
   mvn:org.apache.jclouds.karaf/jclouds-karaf-labs/${jclouds.karaf.version}/xml/features
 
-featuresBoot=\
-  shell-compat,config,log,feature, \
-  jclouds-chef,jclouds-aws-ec2,jclouds-aws-s3
+featuresBoot=shell-compat,config,log,feature,${jclouds.karaf.boot-features}

--- a/branding/pom.xml
+++ b/branding/pom.xml
@@ -29,7 +29,7 @@
 
   <artifactId>jclouds-cli-branding</artifactId>
   <packaging>bundle</packaging>
-  <name>jclouds :: cli :: branding</name>
+  <name>Apache jclouds :: cli :: branding</name>
 
   <properties>
     <osgi.export>org.apache.karaf.branding</osgi.export>

--- a/project/pom.xml
+++ b/project/pom.xml
@@ -31,7 +31,7 @@
   <artifactId>jclouds-cli-project</artifactId>
   <version>2.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
-  <name>Apache jclouds :: cli</name>
+  <name>Apache jclouds :: cli :: project</name>
 
   <url>http://jclouds.apache.org</url>
   <licenses>
@@ -80,6 +80,7 @@
     <asm.version>5.0.4</asm.version>
     <felix.fileinstall.version>3.5.8</felix.fileinstall.version>
     <jclouds.karaf.version>${project.parent.version}</jclouds.karaf.version>
+    <jclouds.karaf.boot-features>jclouds-all-compute,jclouds-all-blobstore,jclouds-chef</jclouds.karaf.boot-features>
     <jclouds.version>${project.parent.version}</jclouds.version>
     <log4j.version>1.2.17</log4j.version>
     <slf4j.version>1.7.7</slf4j.version>

--- a/runner/pom.xml
+++ b/runner/pom.xml
@@ -28,7 +28,7 @@
   </parent>
 
   <artifactId>jclouds-cli-runner</artifactId>
-  <name>jclouds :: cli :: runner</name>
+  <name>Apache jclouds :: cli :: runner</name>
 
   <dependencies>
     <dependency>


### PR DESCRIPTION
Enabling all features has no impact on the size of the package, so there is no reason not to preinstall all non-labs features. I've made the list configurable anyway to let users customize that at build time.